### PR TITLE
Fix issue setting quality property to omxjpegenc in NULL state

### DIFF
--- a/omx/gstomxjpegenc.c
+++ b/omx/gstomxjpegenc.c
@@ -164,7 +164,8 @@ gst_omx_jpeg_enc_set_property (GObject * object, guint prop_id,
   switch (prop_id) {
     case PROP_QUALITY:
       self->quality = g_value_get_int (value);
-      gst_omx_jpeg_enc_set_format (GST_OMX_VIDEO_ENC (object), NULL, NULL);
+      if (GST_STATE_NULL != GST_STATE (object))
+        gst_omx_jpeg_enc_set_format (GST_OMX_VIDEO_ENC (object), NULL, NULL);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);


### PR DESCRIPTION
In NULL state calling set_format fails since the output port is required but created while going to READY state