### PR TITLE
Fix instability issue with seek events

### DIFF
--- a/omx/gstomxaudiodec.c
+++ b/omx/gstomxaudiodec.c
@@ -1043,7 +1043,13 @@ gst_omx_audio_dec_handle_frame (GstAudioDecoder * decoder, GstBuffer * inbuf)
   GST_DEBUG_OBJECT (self, "Handling frame");
 
   if (self->downstream_flow_ret != GST_FLOW_OK) {
-    return self->downstream_flow_ret;
+    if (self->downstream_flow_ret == GST_FLOW_FLUSHING) {
+      self->downstream_flow_ret = GST_FLOW_OK;
+    } else {
+      GST_ERROR_OBJECT (self, "Downstream flow return: %s",
+          gst_flow_get_name (self->downstream_flow_ret));
+      return self->downstream_flow_ret;
+    }
   }
 
   if (!self->started) {

--- a/omx/gstomxaudiodec.c
+++ b/omx/gstomxaudiodec.c
@@ -1044,6 +1044,7 @@ gst_omx_audio_dec_handle_frame (GstAudioDecoder * decoder, GstBuffer * inbuf)
 
   if (self->downstream_flow_ret != GST_FLOW_OK) {
     if (self->downstream_flow_ret == GST_FLOW_FLUSHING) {
+      /* Avoid returning with error code when the element is flushing because it would stop the incoming stream */
       self->downstream_flow_ret = GST_FLOW_OK;
     } else {
       GST_ERROR_OBJECT (self, "Downstream flow return: %s",


### PR DESCRIPTION
Avoid returning with error code when the pipeline is flushing because of a seek event since it stops the incoming stream