### PR TITLE
Ensure the audio format info structure is set when the first buffer is processed

### DIFF
--- a/omx/gstomxaudiodec.h
+++ b/omx/gstomxaudiodec.h
@@ -66,6 +66,7 @@ struct _GstOMXAudioDec
   /* TRUE if the component is configured and saw
    * the first buffer */
   gboolean started;
+  gboolean audio_info_set;
 
   GstClockTime last_upstream_ts;
 


### PR DESCRIPTION
This fixes an issue when playing segmented files, in that case the pads have the caps set and it causes the audio info structure to not be set properly and the playback fails.