### PR TITLE
Fix blocking issue when seeking to the end of some video files in paused state

### DIFF
--- a/omx/gstomxvideodec.c
+++ b/omx/gstomxvideodec.c
@@ -1600,16 +1600,6 @@ eos:
   {
     g_mutex_lock (&self->drain_lock);
     if (self->draining) {
-      /* In reverse playback, we just need to confirm the component has processed
-         the given block of buffers */
-      if (GST_VIDEO_DECODER(self)->input_segment.rate > 0.0) {
-        GstQuery *query = gst_query_new_drain ();
-        /* Drain the pipeline to reclaim all memories back to the pool */
-        if (!gst_pad_peer_query (GST_VIDEO_DECODER_SRC_PAD (self), query))
-          GST_DEBUG_OBJECT (self, "drain query failed");
-        gst_query_unref (query);
-      }
-
       GST_DEBUG_OBJECT (self, "Drained");
       self->draining = FALSE;
       g_cond_broadcast (&self->drain_cond);


### PR DESCRIPTION
Remove drain query since it's not necessary and causes blocking issues with the
empty EOS buffer drain method that was enabled for reverse playback support. Using this
drain method we ensure the component has processed completely the given block of buffers.